### PR TITLE
Fix LiDAR rotation Jacobian translation term

### DIFF
--- a/fastlio2/src/map_builder/lidar_processor.cpp
+++ b/fastlio2/src/map_builder/lidar_processor.cpp
@@ -242,7 +242,7 @@ void LidarProcessor::updateLossFunc(State &state, SharedState &share_data)
         const PointType &norm_p = m_effect_norm_vec->points[i];
         Eigen::Vector3d laser_p_vec(laser_p.x, laser_p.y, laser_p.z);
         Eigen::Vector3d norm_vec(norm_p.x, norm_p.y, norm_p.z);
-        Eigen::Matrix<double, 1, 3> B = -norm_vec.transpose() * state.r_wi * Sophus::SO3d::hat(state.r_il * laser_p_vec + state.t_wi);
+        Eigen::Matrix<double, 1, 3> B = -norm_vec.transpose() * state.r_wi * Sophus::SO3d::hat(state.r_il * laser_p_vec + state.t_il);
         J.block<1, 3>(0, 0) = B;
         J.block<1, 3>(0, 3) = norm_vec.transpose();
         if (m_config.esti_il)


### PR DESCRIPTION
## Summary

Fix the rotational measurement Jacobian by using the fixed LiDAR-to-IMU translation `state.t_il` instead of the world-frame IMU translation `state.t_wi`.

For a LiDAR point,

```text
p_w = R_wi (R_il p_l + t_il) + t_wi
```

so differentiation with respect to the IMU rotation must use the lever arm

```text
R_il p_l + t_il
```

inside the skew-symmetric matrix.

Using `t_wi` makes the Jacobian depend on the arbitrary world origin and causes its magnitude and conditioning to deteriorate as the robot travels farther from the origin. In our tests this eventually caused pose divergence followed by `NO Effective Points`. Restarting FAST-LIO changed the location of the failure, which was another consequence of resetting the world origin.

## Validation

Before this correction, a diagnostic run failed after approximately 16 m, with 133 scans falling below 100 correspondences and a maximum normal-matrix condition estimate of approximately `2.3e18`.

After changing only `state.t_wi` to `state.t_il`, the same system completed a 698-second, 6,673-scan mapping run covering approximately 45 m from the origin:

* minimum effective correspondences: 497
* maximum condition estimate: approximately 616
* no `NO Effective Points` failure
* complete corridor loop mapped successfully, including the previously repeatable failure locations

This is also consistent with the transformation used by the original FAST-LIO implementation.
